### PR TITLE
feat: adiciona página de BitDevs em outras cidades

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -8,3 +8,4 @@ menu:
       url: "https://www.meetup.com/pt-BR/brasilia-bitcoin/",
       external: true,
     }
+  - { name: "Cidades", url: "/cities" }

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -8,4 +8,4 @@ menu:
       url: "https://www.meetup.com/pt-BR/brasilia-bitcoin/",
       external: true,
     }
-  - { name: "Cidades", url: "/cities" }
+  - { name: "Outras Cidades", url: "/cities" }

--- a/cities.html
+++ b/cities.html
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Cidades
+---
+<div class="Home">
+    <p class="Home-about">
+        O formato BitDevs se espalhou por várias cidades do Brasil. Se você estiver viajando ou quiser conhecer outras comunidades, aqui vai uma lista com alguns grupos ativos.
+    </p>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do Brasil</h2>
+        <ul>
+            <li><a href="https://bhbitdevs.org/" target="_blank" rel="noopener nofollow">Belo Horizonte</a></li>
+            <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
+            <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
+            <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
+            <li><a href="https://bitdevsportugues.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+        </ul>
+    </div>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do mundo</h2>
+        <p>
+            <a href="https://bitdevs.org/cities" target="_blank" rel="noopener nofollow">
+                Ver a lista global mantida pelo BitDevs NYC
+            </a>
+        </p>
+    </div>
+</div>

--- a/cities.html
+++ b/cities.html
@@ -14,7 +14,7 @@ title: Outras Cidades
             <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
             <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
             <li><a href="https://poabitdevs.org/" target="_blank" rel="noopener nofollow">Porto Alegre</a></li>
-            <li><a href="https://bitdevsportugues.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+            <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
         </ul>
     </div>
 

--- a/cities.html
+++ b/cities.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Cidades
+title: Outras Cidades
 ---
 <div class="Home">
     <p class="Home-about">


### PR DESCRIPTION
## Resumo
- adiciona uma nova aba `Cidades` no menu principal
- cria uma página com links para BitDevs de outras cidades do Brasil
- adiciona um link separado para a lista global mantida pelo BitDevs NYC

## Validação
- `git diff --check`
- build Jekyll local não executado porque a máquina não tem `bundler 2.4.22`, versão exigida pelo `Gemfile.lock`